### PR TITLE
feature: added 404 page not found

### DIFF
--- a/Client/src/App.jsx
+++ b/Client/src/App.jsx
@@ -13,6 +13,7 @@ import ProtectedRoutesComponent from './components/ProtectedRoutesComponent'
 import SpeedDialComponent from './components/SpeedDialComponente'
 import CreatePostPage from './pages/CreatePostPage'
 import {  useState } from 'react'
+import NotFoundPage from './pages/404Page'
 
 
 
@@ -31,8 +32,10 @@ function App() {
       <>
         <SpeedDialComponent />
         <Router>
+     
           <HeaderComponent />
           <Routes>
+          <Route path="*" element={<NotFoundPage />} />
             <Route exact path="/" element={<HomePage setIsLoading={setIsLoading} />} />
             <Route path="/login" element={<LoginPage setIsLoading={setIsLoading} />} />
             <Route path="/register" element={<RegisterPage setIsLoading={setIsLoading} />} />

--- a/Client/src/pages/404Page.jsx
+++ b/Client/src/pages/404Page.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import 'bootstrap/dist/css/bootstrap.min.css';
+
+const NotFoundPage = () => {
+    return (
+        <div className="d-flex align-items-center justify-content-center vh-100 bg-light">
+            <div className="text-center p-5 shadow-lg rounded" style={{ maxWidth: '600px', backgroundColor: '#fff' }}>
+                <div className="display-1 fw-bold text-danger">404</div>
+                <div className="h4 text-secondary mb-4">Oops! The page you are looking for does not exist.</div>
+                <p className="lead text-muted mb-4">It looks like you might have taken a wrong turn. Don't worry, it happens to the best of us. Let's get you back on track.</p>
+                <a href="/" className="btn btn-outline-primary btn-lg">Go Back Home</a>
+            </div>
+        </div>
+    );
+};
+
+export default NotFoundPage;


### PR DESCRIPTION

This PR adds a dedicated 404 Page Not Found component to the application. The 404 page is designed to be visually appealing and provides a clear message to users when they navigate to a non-existent route. 

## Changes Made:
- **Created a new `NotFoundPage` component**:
  - Includes a large error code (404) with a descriptive message.
  - Styled using Bootstrap 5 for a clean and modern look.
  - Features a "Go Back Home" button that redirects users to the homepage.
- **Updated `App.js`**:
  - Added a new route (`*`) to handle all unmatched routes, rendering the `NotFoundPage` component.
  - based on the current route. This ensures that these components are not displayed on the 404 page, providing a focused view of the error message.
  
## Demo
![Screenshot 2024-05-31 at 8 24 35 PM](https://github.com/singhJasvinder101/MyBlog/assets/109215419/64b837d4-1406-46ed-9d8a-04527abd3ae5)


## How to Test
1. Start the application.
2. Navigate to a non-existent route (e.g., `/non-existent-page`).
3. Verify that the 404 Page Not Found component is displayed with no header or footer.
4. Click the "Go Back Home" button to ensure it redirects to the homepage.

## Issue Reference
This PR addresses and closes issue #32 .
